### PR TITLE
Remove outdated code.google.com link

### DIFF
--- a/article.html
+++ b/article.html
@@ -5728,8 +5728,6 @@ done
       <a href="http://www.clojureatlas.com/">http://www.clojureatlas.com/</a></li>
       <li>Clojure class diagram -
       <a href="http://github.com/Chouser/clojure-classes/tree/master/graph-w-legend.png">http://github.com/Chouser/clojure-classes/tree/master/graph-w-legend.png</a></li>
-      <li>clojure-contrib documentation -
-      <a href="http://code.google.com/p/clojure-contrib/wiki/OverviewOfContrib/">http://code.google.com/p/clojure-contrib/wiki/OverviewOfContrib/</a></li>
       <li>Wikibooks Clojure Programming - <a href="http://en.wikibooks.org/wiki/Clojure_Programming">http://en.wikibooks.org/wiki/Clojure_Programming</a></li>
       <li>Wikibooks Learning Clojure - <a href="http://en.wikibooks.org/wiki/Learning_Clojure">http://en.wikibooks.org/wiki/Learning_Clojure</a></li>
       <li>Wikibooks Clojure API Examples - <a href="http://en.wikibooks.org/wiki/Clojure_Programming/Examples/API_Examples">http://en.wikibooks.org/wiki/Clojure_Programming/Examples/API_Examples</a></li>


### PR DESCRIPTION
Just removing one old broken link.

(John Gabriele had fixed the other links which I'd noticed were broken and had previously tried to remove)
