### PR TITLE
Changed "Bindings" to "Vars"

### DIFF
--- a/article.html
+++ b/article.html
@@ -1172,11 +1172,13 @@ user=&gt; (* n 3)
       Function parameters are bound to Vars that are local to the function.
     </p>
     <p>
-      The <code>def</code> macro binds a value to a symbol and provides
-      mechanism to assign that binding a thread-local value, via the <code>:dynamic</code> declaration.
-      In other words it allows re-definition of assigned value per execution thread
+      The <code>def</code> macro binds a value to a symbol. It provides a
+      mechanism to define metadata, <code>:dynamic</code>,  which allows a thread-local value
+      within the scope of a <code>binding</code> call.
+      In other words, it allows re-definition of assigned value per execution thread
       and scope. If the Var is not re-assigned to a new value in a separate
-      execution thread, the Var simply behaves like a global binding to that value.
+      execution thread, the Var refers to the value of the root binding,
+      if accessed from another thread.
     <p>
       The <code>let</code> macro creates bindings to Vars 
       that are bound to the scope within the statement.


### PR DESCRIPTION
Changed "Bindings" to "Vars" since Var is the name used in the official Clojure documentation.
- moved comments in code examples to the line above the code being documented. This was done for readability.
- edited example code for readability.
- edited text to clarify the overall idea of mutable values within the context of execution threads.

I am just learning about Clojure and thought I would take some time to clarify my understanding of binding Vars while reading your article. I would appreciate corrections and comments regarding the edits I made. 

Cheers,
Isaac
