### PR TITLE
Update of metadata section for newer style of retrieving metadata.

### DIFF
--- a/article.html
+++ b/article.html
@@ -3857,7 +3857,7 @@ Output from pr:
     <div class="code">
 <pre xml:space="preserve">
 ((meta (var and)) :macro) ; long way -&gt; true
-(^#'and :macro) ; short way -&gt; true
+((meta #'and) :macro) ; slightly shorter way -&gt; true
 </pre>
 </div>
     <p>


### PR DESCRIPTION
The ^#'and call is deprecated and (at least in >1.4) will fail and throw an exception. The way to retrieve metadata is now with (meta *).
