### PR TITLE
Included link for ClojureCLR repo and removed alpha status from it.

### DIFF
--- a/article.html
+++ b/article.html
@@ -364,10 +364,10 @@
       it was an easy decision."
     </p>
     <p>
-      Soon Clojure will also be available for the .NET platform.
+      Clojure is also available for the .NET platform.
       ClojureCLR is an implementation of Clojure that runs on the
       Microsoft Common Language Runtime instead of the JVM.
-      At the time of this writing it is considered to be alpha quality.
+      See <a href="https://github.com/clojure/clojure-clr">https://github.com/clojure/clojure-clr</a>.
     </p>
     <p>
       In July 2011, ClojureScript was announced.


### PR DESCRIPTION
According to their GitHub Wiki - "ClojureCLR development closely tracks progress in the ClojureJVM project. We index many of our commits directly to commits in the Clojure repo, so it should be easy to track our progress. We try to be within a week or so of development milestones on the main Clojure project."

So I think we should not use alpha for it now and encourage everybody to give ClojureCLR a spin.
