### PR TITLE
Update link to Simon Peyton Jones talk

### DIFF
--- a/article.html
+++ b/article.html
@@ -292,7 +292,7 @@
       "In the end, any program must manipulate state.
        A program that has no side effects whatsoever is a kind of black box.
        All you can tell is that the box gets hotter."
-       (<a href="http://oscon.blip.tv/file/324976">http://oscon.blip.tv/file/324976</a>)
+       (<a href="http://www.youtube.com/watch?v=iSmkqocn0oQ&t=3m20s">http://www.youtube.com/watch?v=iSmkqocn0oQ&t=3m20s</a>)
       The key is to limit side effects, clearly identify them,
       and avoid scattering them throughout the code.
     </p>


### PR DESCRIPTION
Original link (blip.tv) has gone offline.

This change usess a link to Simon Peyton Jones making the same "black box" point in a different talk.
