### PR TITLE
Clarified the cons/conj list return type

### DIFF
--- a/article.html
+++ b/article.html
@@ -1397,9 +1397,10 @@ after calling f4, v: 4
 </pre>
 </div>
     <p>
-      Both the <code>conj</code> and <code>cons</code> functions
-      create a new list
-      that contains additional items added to the front.
+      While the <code>conj</code> function will create a new
+      list, the <code>cons</code> function will create a new
+      sequence (more about that in the Sequences chapter). In each
+      case the new item(s) are added to the front.
       The <code>remove</code> function creates a new list containing
       only the items for which a predicate function returns false.
       For example:


### PR DESCRIPTION
While reading through the article, I went looking for clarification of cons/conj.  I ran into a thread that described the two functions as expanded to:

conj(oin items)
cons(truct a sequence)

And after doing some poking around in the repl, it is true that the returned classes from conj and cons are not the same:

```
user=> (def stooges (list "Moe" "Larry" "Curly"))
#'user/stooges
user=> (class (conj stooges "Shemp"))
clojure.lang.PersistentList
user=> (class (cons "Shemp" stooges))
clojure.lang.Cons
```

I am a Clojure newb though, and so I don't know if a Cons is more similar to a PersistentList than a LazySeq type. Meaning, I don't know enough of clojure to know if this change is more confusing than helpful.  If a Cons quacks like a List, then this is probably more confusing. But, saying that both return a list isn't quite true (but it might be true enough). 
