### PR TITLE
Link for Compojure deps no longer accessible

### DIFF
--- a/article.html
+++ b/article.html
@@ -5436,17 +5436,20 @@ git clone git://github.com/weavejester/compojure.git
     <p>
       This creates a directory named <code>compojure</code>
       in the current directory.
-      <del></del></de>Additional JARs must be downloaded from
+      <del>Additional JARs must be downloaded from
       <a href="http://cloud.github.com/downloads/weavejester/compojure/deps.zip">http://cloud.github.com/downloads/weavejester/compojure/deps.zip</a>.
       Place <code>deps.zip</code> in the <code>compojure</code> directory
       and unzip it to create a <code>deps</code> subdirectory.</del>
-	  <cite>Repo above is no longer accessible. Please use <code>lein deps</code> to download dependencies. This will not, however, create a subdirectory.</cite>
+	  <b>Link is no longer accessible.</b> Please use <code>lein deps</code> to download dependencies. This will not, however, create a subdirectory. (2019)
     </p>
     <p>
       To build <code>compojure.jar</code>,
       run <code>ant</code> from the compojure directory.
-	  <cite>Alternatively, use <code>lein jars</code> to create compojure.jar.</cite>
+	  <i>Alternatively, use <code>lein jar</code>.</i> (2019)
     </p>
+	<p>
+		If you are having any trouble with <code>ant</code> or getting the necessary dependencies, check out <a href="https://en.wikibooks.org/wiki/Compojure/Getting_Started"><cite>Compojure/Getting Started</cite></a> on Wikibooks for help. (2019)
+	</p>
     <p>
       To get updates to Compojure,
       cd to the <code>compojure</code> directory

--- a/article.html
+++ b/article.html
@@ -5436,14 +5436,16 @@ git clone git://github.com/weavejester/compojure.git
     <p>
       This creates a directory named <code>compojure</code>
       in the current directory.
-      Additional JARs must be downloaded from
+      <del></del></de>Additional JARs must be downloaded from
       <a href="http://cloud.github.com/downloads/weavejester/compojure/deps.zip">http://cloud.github.com/downloads/weavejester/compojure/deps.zip</a>.
       Place <code>deps.zip</code> in the <code>compojure</code> directory
-      and unzip it to create a <code>deps</code> subdirectory.
+      and unzip it to create a <code>deps</code> subdirectory.</del>
+	  <cite>Repo above is no longer accessible. Please use <code>lein deps</code> to download dependencies. This will not, however, create a subdirectory.</cite>
     </p>
     <p>
       To build <code>compojure.jar</code>,
       run <code>ant</code> from the compojure directory.
+	  <cite>Alternatively, use <code>lein jars</code> to create compojure.jar.</cite>
     </p>
     <p>
       To get updates to Compojure,


### PR DESCRIPTION
The link detailed in the "Web Application" section that contains the necessary deps.zip is no longer accessible. I added an alternative way of getting the dependencies by using 'lein deps' command. This is assuming that Leiningen is install, which is required for this section.

In addition, 'lein jar' can be used to create a jar file for Compojure as the 'ant' command may not work for everyone. For myself, 'ant' does not work with my Git Bash, which is my primary terminal.

I also added a link to the reference I obtained this information from. I was ensure if it was permissible to add the link to the "References" section.